### PR TITLE
Fix OutOfMemory Error while running unit test PartitionGroupStoreManagerTest. 

### DIFF
--- a/joyqueue-server/joyqueue-broker-core/src/test/java/com/jd/joyqueue/broker/election/ElectionManagerTest.java
+++ b/joyqueue-server/joyqueue-broker-core/src/test/java/com/jd/joyqueue/broker/election/ElectionManagerTest.java
@@ -55,12 +55,12 @@ public class ElectionManagerTest {
 
     private String getStoreDir() {
         String property = "java.io.tmpdir";
-        return System.getProperty(property) + "store";
+        return System.getProperty(property) + File.separator + "store";
     }
 
     private String getElectionDir() {
         String property = "java.io.tmpdir";
-        return System.getProperty(property) + "election";
+        return System.getProperty(property) + File.separator + "election";
     }
 
     @Before

--- a/joyqueue-server/joyqueue-broker-core/src/test/java/com/jd/joyqueue/broker/election/ElectionMetadataManagerTest.java
+++ b/joyqueue-server/joyqueue-broker-core/src/test/java/com/jd/joyqueue/broker/election/ElectionMetadataManagerTest.java
@@ -48,12 +48,12 @@ public class ElectionMetadataManagerTest {
 
     private String getStoreDir() {
         String property = "java.io.tmpdir";
-        return System.getProperty(property) + "store";
+        return System.getProperty(property) + File.separator + "store";
     }
 
     private String getElectionDir() {
         String property = "java.io.tmpdir";
-        return System.getProperty(property) + "election";
+        return System.getProperty(property) + File.separator + "election";
     }
 
     @Before

--- a/joyqueue-server/joyqueue-broker-core/src/test/java/com/jd/joyqueue/broker/election/FixedLeaderElectionTest.java
+++ b/joyqueue-server/joyqueue-broker-core/src/test/java/com/jd/joyqueue/broker/election/FixedLeaderElectionTest.java
@@ -62,12 +62,12 @@ public class FixedLeaderElectionTest {
 
     private String getStoreDir() {
         String property = "java.io.tmpdir";
-        return System.getProperty(property) + "store";
+        return System.getProperty(property) + File.separator + "store";
     }
 
     private String getElectionDir() {
         String property = "java.io.tmpdir";
-        return System.getProperty(property) + "election";
+        return System.getProperty(property) + File.separator + "election";
     }
 
     @Before

--- a/joyqueue-server/joyqueue-broker-core/src/test/java/com/jd/joyqueue/broker/election/RaftLeaderElectionTest.java
+++ b/joyqueue-server/joyqueue-broker-core/src/test/java/com/jd/joyqueue/broker/election/RaftLeaderElectionTest.java
@@ -67,12 +67,12 @@ public class RaftLeaderElectionTest {
 
     private String getStoreDir() {
         String property = "java.io.tmpdir";
-        return System.getProperty(property) + "store";
+        return System.getProperty(property)  + File.separator + "store";
     }
 
     private String getElectionDir() {
         String property = "java.io.tmpdir";
-        return System.getProperty(property) + "election";
+        return System.getProperty(property)  + File.separator + "election";
     }
 
     @Before

--- a/joyqueue-server/joyqueue-store/joyqueue-store-core/src/main/java/com/jd/joyqueue/store/Store.java
+++ b/joyqueue-server/joyqueue-store/joyqueue-store-core/src/main/java/com/jd/joyqueue/store/Store.java
@@ -158,9 +158,9 @@ public class Store extends Service implements StoreService, Closeable, PropertyS
 
     public void checkOrCreateBase() {
         if (!base.exists()) {
-            if (!base.mkdirs()) throw new StoreInitializeException();
+            if (!base.mkdirs()) throw new StoreInitializeException(String.format("Failed to create directory: %s.", base.getAbsolutePath()));
         } else {
-            if (!base.isDirectory()) throw new StoreInitializeException();
+            if (!base.isDirectory()) throw new StoreInitializeException(String.format("Failed to create directory: %s! Cause: file exists!", base.getAbsolutePath()));
         }
     }
 

--- a/joyqueue-server/joyqueue-store/joyqueue-store-core/src/main/java/com/jd/joyqueue/store/cli/MessageViewer.java
+++ b/joyqueue-server/joyqueue-store/joyqueue-store-core/src/main/java/com/jd/joyqueue/store/cli/MessageViewer.java
@@ -56,7 +56,6 @@ public class MessageViewer {
 
 
         PreloadBufferPool bufferPool = PreloadBufferPool.getInstance();
-        bufferPool.addPreLoad(PositioningStore.Config.DEFAULT_FILE_DATA_SIZE, 1, 1);
 
         PositioningStore<ByteBuffer> store =
                 new PositioningStore<>(base, storeConfig, bufferPool, new StoreMessageSerializer(1024 * 1024));

--- a/joyqueue-server/joyqueue-store/joyqueue-store-core/src/main/java/com/jd/joyqueue/store/cli/RecoverStore.java
+++ b/joyqueue-server/joyqueue-store/joyqueue-store-core/src/main/java/com/jd/joyqueue/store/cli/RecoverStore.java
@@ -379,8 +379,6 @@ public class RecoverStore {
             System.out.println("All files will be checked.");
         }
         PreloadBufferPool pool = PreloadBufferPool.getInstance();
-        pool.addPreLoad(StoreConfig.DEFAULT_INDEX_FILE_SIZE, 0, 1);
-        pool.addPreLoad(StoreConfig.DEFAULT_MESSAGE_FILE_SIZE, 0, 1);
 
         PositioningStore<ByteBuffer> logStore =
                 new PositioningStore<>(base, new PositioningStore.Config(StoreConfig.DEFAULT_MESSAGE_FILE_SIZE),

--- a/joyqueue-server/joyqueue-store/joyqueue-store-core/src/main/java/com/jd/joyqueue/store/utils/PreloadBufferPool.java
+++ b/joyqueue-server/joyqueue-store/joyqueue-store-core/src/main/java/com/jd/joyqueue/store/utils/PreloadBufferPool.java
@@ -23,7 +23,6 @@ import sun.misc.Cleaner;
 import sun.misc.VM;
 import sun.nio.ch.DirectBuffer;
 
-import java.io.Closeable;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -43,7 +42,7 @@ import java.util.stream.Stream;
  * @author liyue25
  * Date: 2018-12-20
  */
-public class PreloadBufferPool implements Closeable {
+public class PreloadBufferPool {
     public static final long DEFAULT_CACHE_LIFE_TIME_MS = 60000L;
     public static final long INTERVAL_MS = 50L;
     private static final Logger logger = LoggerFactory.getLogger(PreloadBufferPool.class);
@@ -72,6 +71,7 @@ public class PreloadBufferPool implements Closeable {
     public static PreloadBufferPool getInstance() {
         if(null == instance) {
             instance = new PreloadBufferPool();
+            Runtime.getRuntime().addShutdownHook(new Thread(instance::close));
         }
         return instance;
     }
@@ -198,7 +198,7 @@ public class PreloadBufferPool implements Closeable {
         return bufferCache.putIfAbsent(bufferSize, new PreLoadCache(bufferSize, coreCount, maxCount)) == null;
     }
 
-    public void close() {
+    private void close() {
         this.preloadThread.stop();
         this.evictThread.stop();
         if (this.metricThread != null) {
@@ -339,7 +339,6 @@ public class PreloadBufferPool implements Closeable {
 
     /**
      * buffer监控
-     * @return
      */
     public BufferPoolMonitorInfo monitorInfo() {
         BufferPoolMonitorInfo bufferPoolMonitorInfo = new BufferPoolMonitorInfo();

--- a/joyqueue-server/joyqueue-store/joyqueue-store-core/src/test/java/com/jd/joyqueue/store/PartitionGroupStoreManagerTest.java
+++ b/joyqueue-server/joyqueue-store/joyqueue-store-core/src/test/java/com/jd/joyqueue/store/PartitionGroupStoreManagerTest.java
@@ -164,8 +164,6 @@ public class PartitionGroupStoreManagerTest {
         if (null == virtualThreadPool) virtualThreadPool = new VirtualThreadExecutor(500, 100, 10, 1000, 4);
         if (null == bufferPool) {
             bufferPool = PreloadBufferPool.getInstance();
-            bufferPool.addPreLoad(128 * 1024 * 1024, 2, 4);
-            bufferPool.addPreLoad(10 * 1024 * 1024, 2, 4);
         }
 
         this.store = new PartitionGroupStoreManager(topic, partitionGroup, groupBase, new PartitionGroupStoreManager.Config(),
@@ -556,8 +554,6 @@ public class PartitionGroupStoreManagerTest {
         if (null == virtualThreadPool) virtualThreadPool = new VirtualThreadExecutor(500, 100, 10, 1000, 4);
         if (null == bufferPool) {
             bufferPool = PreloadBufferPool.getInstance();
-            bufferPool.addPreLoad(128 * 1024 * 1024, 0, 0);
-            bufferPool.addPreLoad(10 * 1024 * 1024, 0, 0);
         }
 
         this.store = new PartitionGroupStoreManager(topic, partitionGroup, groupBase, new PartitionGroupStoreManager.Config(),
@@ -582,7 +578,6 @@ public class PartitionGroupStoreManagerTest {
         }
 
         if (null != bufferPool) {
-            bufferPool.close();
             bufferPool = null;
         }
     }

--- a/joyqueue-server/joyqueue-store/joyqueue-store-core/src/test/java/com/jd/joyqueue/store/PartitionGroupStoreManagerTest.java
+++ b/joyqueue-server/joyqueue-store/joyqueue-store-core/src/test/java/com/jd/joyqueue/store/PartitionGroupStoreManagerTest.java
@@ -556,8 +556,8 @@ public class PartitionGroupStoreManagerTest {
         if (null == virtualThreadPool) virtualThreadPool = new VirtualThreadExecutor(500, 100, 10, 1000, 4);
         if (null == bufferPool) {
             bufferPool = PreloadBufferPool.getInstance();
-            bufferPool.addPreLoad(128 * 1024 * 1024, 2, 4);
-            bufferPool.addPreLoad(10 * 1024 * 1024, 2, 4);
+            bufferPool.addPreLoad(128 * 1024 * 1024, 0, 0);
+            bufferPool.addPreLoad(10 * 1024 * 1024, 0, 0);
         }
 
         this.store = new PartitionGroupStoreManager(topic, partitionGroup, groupBase, new PartitionGroupStoreManager.Config(),

--- a/joyqueue-server/joyqueue-store/joyqueue-store-core/src/test/java/com/jd/joyqueue/store/file/PositioningStoreTest.java
+++ b/joyqueue-server/joyqueue-store/joyqueue-store-core/src/test/java/com/jd/joyqueue/store/file/PositioningStoreTest.java
@@ -55,7 +55,6 @@ public class PositioningStoreTest {
     public void messageWriteReadTest() throws IOException, TimeoutException, InterruptedException {
         VirtualThreadExecutor virtualThreadPool = new VirtualThreadExecutor(500, 100, 10, 1000, 4);
         PreloadBufferPool bufferPool = PreloadBufferPool.getInstance();
-        bufferPool.addPreLoad(PositioningStore.Config.DEFAULT_FILE_DATA_SIZE, 1, 1);
 
         PositioningStore<ByteBuffer> store =
                 new PositioningStore<>(logBase, new PositioningStore.Config(),
@@ -78,7 +77,6 @@ public class PositioningStoreTest {
         Assert.assertEquals(bodyList, readBodyList);
         store.close();
         virtualThreadPool.stop();
-        bufferPool.close();
     }
 
     // recover
@@ -95,7 +93,6 @@ public class PositioningStoreTest {
                 PositioningStore.Config.DEFAULT_FILE_HEADER_SIZE);
         VirtualThreadExecutor virtualThreadPool = new VirtualThreadExecutor(500, 100, 10, 1000, 4);
         PreloadBufferPool bufferPool = PreloadBufferPool.getInstance();
-        bufferPool.addPreLoad(fileDataSize, 1, 1);
 
         StoreMessageSerializer factory = new StoreMessageSerializer(1024 * 1024);
         PositioningStore<ByteBuffer> store =
@@ -120,7 +117,6 @@ public class PositioningStoreTest {
         List<String> readBodyList = MessageTestUtils.getBodies(readLogs);
         Assert.assertEquals(bodyList, readBodyList);
         store.close();
-        bufferPool.close();
         virtualThreadPool.stop();
 
     }
@@ -139,7 +135,6 @@ public class PositioningStoreTest {
         PositioningStore.Config config = new PositioningStore.Config(fileDataSize,
                 PositioningStore.Config.DEFAULT_FILE_HEADER_SIZE);
         PreloadBufferPool bufferPool = PreloadBufferPool.getInstance();
-        bufferPool.addPreLoad(fileDataSize, 1, 1);
 
         StoreMessageSerializer factory = new StoreMessageSerializer(1024 * 1024);
         PositioningStore<ByteBuffer> store =
@@ -181,7 +176,6 @@ public class PositioningStoreTest {
     public void messageSetRightTest() throws IOException, InterruptedException, TimeoutException {
         VirtualThreadExecutor virtualThreadPool = new VirtualThreadExecutor(500, 100, 10, 1000, 4);
         PreloadBufferPool bufferPool = PreloadBufferPool.getInstance();
-        bufferPool.addPreLoad(PositioningStore.Config.DEFAULT_FILE_DATA_SIZE, 1, 1);
         PositioningStore<ByteBuffer> store =
                 new PositioningStore<>(logBase, new PositioningStore.Config(),
                         bufferPool,
@@ -229,7 +223,6 @@ public class PositioningStoreTest {
         store.setRight(position);
         Assert.assertEquals(position, store.right());
         store.close();
-        bufferPool.close();
         virtualThreadPool.stop();
 
     }
@@ -238,7 +231,6 @@ public class PositioningStoreTest {
     public void indexWriteReadTest() throws IOException, InterruptedException, TimeoutException {
         VirtualThreadExecutor virtualThreadPool = new VirtualThreadExecutor(500, 100, 10, 1000, 4);
         PreloadBufferPool bufferPool = PreloadBufferPool.getInstance();
-        bufferPool.addPreLoad(PositioningStore.Config.DEFAULT_FILE_DATA_SIZE, 1, 1);
         PositioningStore<IndexItem> store =
                 new PositioningStore<>(logBase, new PositioningStore.Config(),
                         bufferPool,
@@ -274,7 +266,6 @@ public class PositioningStoreTest {
         PositioningStore.Config config = new PositioningStore.Config(128);
         VirtualThreadExecutor virtualThreadPool = new VirtualThreadExecutor(500, 100, 10, 1000, 4);
         PreloadBufferPool bufferPool = PreloadBufferPool.getInstance();
-        bufferPool.addPreLoad(PositioningStore.Config.DEFAULT_FILE_DATA_SIZE, 1, 1);
         PositioningStore<IndexItem> store =
                 new PositioningStore<>(logBase, new PositioningStore.Config(),
                         bufferPool,
@@ -308,7 +299,6 @@ public class PositioningStoreTest {
         });
 
         store.close();
-        bufferPool.close();
         virtualThreadPool.stop();
     }
 
@@ -320,8 +310,9 @@ public class PositioningStoreTest {
         long maxSize = 1L * 1024 * 1024 * 1024;
         // 每条消息消息体大小
         int logSize = 12;
+        PreloadBufferPool bufferPool = PreloadBufferPool.getInstance();
+        try (PositioningStore<ByteBuffer> store = prepareStore(bufferPool)) {
 
-        try (PreloadBufferPool bufferPool = PreloadBufferPool.getInstance(); PositioningStore<ByteBuffer> store = prepareStore(bufferPool)) {
             ByteBuffer buffer = MessageTestUtils.createMessage(new byte[logSize]);
             write(store, maxSize, buffer);
         }
@@ -333,8 +324,8 @@ public class PositioningStoreTest {
         long maxSize = 1L * 1024 * 1024 * 1024;
         // 每条消息消息体大小
         int logSize = 1024;
-
-        try (PreloadBufferPool bufferPool = PreloadBufferPool.getInstance(); PositioningStore<ByteBuffer> store = prepareStore(bufferPool)) {
+        PreloadBufferPool bufferPool = PreloadBufferPool.getInstance();
+        try (PositioningStore<ByteBuffer> store = prepareStore(bufferPool)) {
             ByteBuffer buffer = MessageTestUtils.createMessage(new byte[logSize]);
             final int msgSize = buffer.remaining();
             long writeSize = write(store, maxSize, buffer);
@@ -351,8 +342,8 @@ public class PositioningStoreTest {
         // 每批读消息大小
         int batchSize = 10 * 1024;
 
-
-        try (PreloadBufferPool bufferPool = PreloadBufferPool.getInstance(); PositioningStore<ByteBuffer> store = prepareStore(bufferPool)) {
+        PreloadBufferPool bufferPool = PreloadBufferPool.getInstance();
+        try (PositioningStore<ByteBuffer> store = prepareStore(bufferPool)) {
             ByteBuffer buffer = MessageTestUtils.createMessage(new byte[logSize]);
             long writeSize = write(store, maxSize, buffer);
             readByteBuffer(store, batchSize, writeSize);
@@ -450,7 +441,6 @@ public class PositioningStoreTest {
         PositioningStore.Config config = new PositioningStore.Config();
         VirtualThreadExecutor virtualThreadPool = new VirtualThreadExecutor(500, 100, 10, 1000, 4);
         PreloadBufferPool bufferPool = PreloadBufferPool.getInstance();
-        bufferPool.addPreLoad(PositioningStore.Config.DEFAULT_FILE_DATA_SIZE, 1, 1);
         PositioningStore<ByteBuffer> store =
                 new PositioningStore<>(logBase, new PositioningStore.Config(),
                         bufferPool,


### PR DESCRIPTION
Reduce memory pre allocation to fix oom error on small memory server while running unit test PartitionGroupStoreManagerTest.